### PR TITLE
Add backup module and versioned update handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # punchbuggy
+
 no punchbacks
+
+## Backup & Versioning quick reference
+
+- **Backups** use the File System Access API to write rotating JSON snapshots to a user-selected folder. Connect a folder from the Data & Log modal, then the app automatically debounces saves, skips identical payloads via hash comparison, and prunes daily snapshots beyond the configured limit.
+- **Metadata** (last backup time, hash) is stored in IndexedDB plus localStorage so status persists even if permission to the folder is revoked.
+- **Versioning** is centralized in `app-version.js`. The manifest, UI, and service worker all read the same value so releasing a new build is as simple as bumping that single version string and redeploying.
+- **Updates** are handled by the service worker. When a new version is available the app shows a banner prompting the user to refresh; after 30 seconds it reloads automatically if the banner is still visible.
+
+Release checklist:
+1. Update `app-version.js` and `manifest.webmanifest` with the new version number.
+2. Deploy static assets.
+3. Open the app to confirm the update banner appears and the backup status still reports correctly.

--- a/app-version.js
+++ b/app-version.js
@@ -1,0 +1,1 @@
+self.PUNCHBUGGY_APP_VERSION = '1.0.0';

--- a/backup.js
+++ b/backup.js
@@ -1,0 +1,375 @@
+(function(){
+  const DB_NAME = 'punchbuggy-backup';
+  const DB_VERSION = 1;
+  const STORE_NAME = 'settings';
+  const HANDLE_KEY = 'directory';
+  const META_KEY = 'meta';
+  const LOCAL_META_KEY = 'punchbuggy-backup-meta';
+
+  const Backup = {
+    AUTO_DELAY_MS: 4000,
+    MAX_DAILY_FILES: 14,
+    MAX_ENTRY_SNAPSHOTS: 120,
+    DAILY_PREFIX: 'punchbuggy-daily-',
+    LATEST_FILE: 'punchbuggy-latest.json',
+    SUPPORTED: typeof window !== 'undefined' && 'showDirectoryPicker' in window,
+    _status: { code: 'idle', message: 'Backups idle' },
+    _handle: null,
+    _meta: null,
+    _dbPromise: null,
+    _pendingTimer: null,
+    _busy: false,
+    _latestHash: null,
+    _callbacks: new Set(),
+    _getState: null,
+
+    init(options = {}) {
+      this._getState = options.getState || null;
+      if (options.onStatusChange) {
+        this.onStatusChange(options.onStatusChange);
+      }
+      this._meta = this._loadMeta();
+      this._latestHash = this._meta.latestHash || null;
+      if (!this.SUPPORTED) {
+        this._updateStatus({ code: 'unsupported', message: 'Backups require a compatible browser.' });
+        return;
+      }
+      this._updateStatus({ code: 'initializing', message: 'Checking backup folder…' });
+      this._restoreHandle().catch(err => {
+        console.error('[Backup] Failed to restore handle', err);
+        this._updateStatus({ code: 'error', message: 'Backup initialization failed', error: err });
+      });
+    },
+
+    onStatusChange(cb) {
+      if (typeof cb === 'function') {
+        this._callbacks.add(cb);
+        if (this._status) {
+          cb(this._status);
+        }
+      }
+      return () => this._callbacks.delete(cb);
+    },
+
+    getStatus() {
+      return this._status;
+    },
+
+    async chooseDirectory() {
+      if (!this.SUPPORTED) {
+        return this._updateStatus({ code: 'unsupported', message: 'Backups require a compatible browser.' });
+      }
+      try {
+        const handle = await window.showDirectoryPicker({ mode: 'readwrite' });
+        await this._persistHandle(handle);
+        this._handle = handle;
+        this._updateStatus({ code: 'ready', message: `Connected to “${handle.name}”`, handleName: handle.name });
+        await this.performBackup('initial-setup');
+      } catch (err) {
+        if (err && err.name === 'AbortError') {
+          this._updateStatus({ code: 'cancelled', message: 'Backup folder selection cancelled.' });
+          return;
+        }
+        console.error('[Backup] chooseDirectory error', err);
+        this._updateStatus({ code: 'error', message: 'Unable to select folder', error: err });
+      }
+    },
+
+    async clearBackupData() {
+      try {
+        const db = await this._openDb();
+        const tx = db.transaction(STORE_NAME, 'readwrite');
+        tx.objectStore(STORE_NAME).delete(HANDLE_KEY);
+        tx.objectStore(STORE_NAME).delete(META_KEY);
+        await this._txDone(tx);
+      } catch (err) {
+        console.error('[Backup] clearBackupData error', err);
+      }
+      this._handle = null;
+      this._meta = { lastBackupAt: null, lastDailyDate: null, latestHash: null };
+      this._latestHash = null;
+      localStorage.removeItem(LOCAL_META_KEY);
+      this._updateStatus({ code: 'disconnected', message: 'Backup folder disconnected.', handleName: null });
+    },
+
+    async triggerManualBackup(reason = 'manual') {
+      if (!this._handle) {
+        this._updateStatus({ code: 'no-handle', message: 'Connect a backup folder first.' });
+        return;
+      }
+      await this.performBackup(reason);
+    },
+
+    handleStoreSave(reason = 'state-change') {
+      if (!this._handle || !this.SUPPORTED) return;
+      if (this._pendingTimer) {
+        clearTimeout(this._pendingTimer);
+      }
+      this._pendingTimer = setTimeout(() => {
+        this.performBackup(reason).catch(err => console.error('[Backup] auto-backup failed', err));
+      }, this.AUTO_DELAY_MS);
+    },
+
+    async performBackup(reason = 'auto') {
+      if (!this._handle) {
+        this._updateStatus({ code: 'no-handle', message: 'Connect a backup folder to enable automatic saves.' });
+        return;
+      }
+      if (!this._getState) {
+        console.warn('[Backup] Missing getState function');
+        return;
+      }
+      if (this._busy) {
+        return;
+      }
+      this._busy = true;
+      try {
+        const hasPermission = await this._ensurePermission(this._handle, 'readwrite', reason !== 'auto');
+        if (!hasPermission) {
+          this._updateStatus({ code: 'needs-permission', message: 'Backup folder needs permission.', handleName: this._handle ? this._handle.name : null });
+          this._busy = false;
+          return;
+        }
+        this._updateStatus({ code: 'busy', message: 'Writing backup…', handleName: this._handle ? this._handle.name : null });
+        const payload = this._buildPayload();
+        const json = JSON.stringify(payload);
+        const hash = await this._hash(json);
+        if (hash && this._latestHash && hash === this._latestHash) {
+          this._updateStatus({ code: 'up-to-date', message: 'Backup already current.', lastBackupAt: this._meta.lastBackupAt || Date.now(), handleName: this._handle ? this._handle.name : null });
+          this._busy = false;
+          return;
+        }
+        await this._writeFile(this.LATEST_FILE, json);
+        const today = new Date().toISOString().slice(0, 10);
+        if (this._meta.lastDailyDate !== today) {
+          const dailyName = `${this.DAILY_PREFIX}${today}.json`;
+          await this._writeFile(dailyName, json);
+          this._meta.lastDailyDate = today;
+        }
+        await this._pruneDailyBackups();
+        const now = Date.now();
+        this._meta.lastBackupAt = now;
+        this._meta.latestHash = hash;
+        this._latestHash = hash;
+        await this._saveMeta();
+        this._updateStatus({ code: 'success', message: 'Backup saved.', lastBackupAt: now, handleName: this._handle ? this._handle.name : null });
+      } catch (err) {
+        console.error('[Backup] performBackup error', err);
+        this._updateStatus({ code: 'error', message: 'Backup failed', error: err, handleName: this._handle ? this._handle.name : null });
+      } finally {
+        this._busy = false;
+      }
+    },
+
+    async _restoreHandle() {
+      try {
+        const db = await this._openDb();
+        const tx = db.transaction(STORE_NAME, 'readonly');
+        const req = tx.objectStore(STORE_NAME).get(HANDLE_KEY);
+        const handle = await this._requestToPromise(req);
+        if (!handle) {
+          this._updateStatus({ code: 'no-handle', message: 'No backup folder connected.' });
+          return;
+        }
+        const hasPermission = await this._ensurePermission(handle, 'readwrite', false);
+        if (!hasPermission) {
+          this._handle = handle;
+          this._updateStatus({ code: 'needs-permission', message: `Re-authorize access to “${handle.name}”.`, handleName: handle.name });
+          return;
+        }
+        this._handle = handle;
+        this._updateStatus({ code: 'ready', message: `Connected to “${handle.name}”.`, lastBackupAt: this._meta.lastBackupAt, handleName: handle.name });
+      } catch (err) {
+        console.error('[Backup] restoreHandle error', err);
+        this._updateStatus({ code: 'error', message: 'Unable to restore backup folder', error: err });
+      }
+    },
+
+    async _ensurePermission(handle, mode = 'readwrite', request = false) {
+      if (!handle) return false;
+      try {
+        if (!handle.queryPermission) {
+          return true;
+        }
+        const query = await handle.queryPermission({ mode });
+        if (query === 'granted') return true;
+        if (query === 'denied' && !request) return false;
+        if (request && handle.requestPermission) {
+          const perm = await handle.requestPermission({ mode });
+          return perm === 'granted';
+        }
+        return false;
+      } catch (err) {
+        console.error('[Backup] ensurePermission error', err);
+        return false;
+      }
+    },
+
+    _buildPayload() {
+      const source = typeof this._getState === 'function' ? this._getState() : null;
+      if (!source) return {};
+      const clone = JSON.parse(JSON.stringify(source));
+      if (Array.isArray(clone.history) && clone.history.length > this.MAX_ENTRY_SNAPSHOTS) {
+        clone.history = clone.history.slice(-this.MAX_ENTRY_SNAPSHOTS);
+      }
+      if (Array.isArray(clone.roundWinners) && clone.roundWinners.length > this.MAX_ENTRY_SNAPSHOTS) {
+        clone.roundWinners = clone.roundWinners.slice(-this.MAX_ENTRY_SNAPSHOTS);
+      }
+      return {
+        timestamp: new Date().toISOString(),
+        appVersion: (typeof window !== 'undefined' && window.PUNCHBUGGY_APP_VERSION) || 'dev',
+        reason: 'punchbuggy-state',
+        payload: clone
+      };
+    },
+
+    async _writeFile(fileName, contents) {
+      const fileHandle = await this._handle.getFileHandle(fileName, { create: true });
+      const writable = await fileHandle.createWritable();
+      await writable.write(contents);
+      await writable.close();
+    },
+
+    async _pruneDailyBackups() {
+      const entries = [];
+      for await (const entry of this._handle.values()) {
+        if (entry.kind === 'file' && entry.name.startsWith(this.DAILY_PREFIX)) {
+          entries.push(entry.name);
+        }
+      }
+      entries.sort();
+      while (entries.length > this.MAX_DAILY_FILES) {
+        const oldest = entries.shift();
+        try {
+          await this._handle.removeEntry(oldest);
+        } catch (err) {
+          console.warn('[Backup] Failed to remove old backup', oldest, err);
+          break;
+        }
+      }
+    },
+
+    async _hash(text) {
+      try {
+        if (window.crypto && window.crypto.subtle) {
+          const enc = new TextEncoder();
+          const buf = enc.encode(text);
+          const digest = await window.crypto.subtle.digest('SHA-256', buf);
+          return Array.from(new Uint8Array(digest)).map(b => b.toString(16).padStart(2, '0')).join('');
+        }
+      } catch (err) {
+        console.warn('[Backup] crypto.subtle unavailable', err);
+      }
+      let hash = 0;
+      for (let i = 0; i < text.length; i++) {
+        hash = ((hash << 5) - hash) + text.charCodeAt(i);
+        hash |= 0;
+      }
+      return `fallback-${hash}`;
+    },
+
+    _loadMeta() {
+      try {
+        const stored = localStorage.getItem(LOCAL_META_KEY);
+        if (stored) {
+          return JSON.parse(stored);
+        }
+      } catch (err) {
+        console.warn('[Backup] failed to read local meta', err);
+      }
+      return { lastBackupAt: null, lastDailyDate: null, latestHash: null };
+    },
+
+    async _saveMeta() {
+      try {
+        const db = await this._openDb();
+        const tx = db.transaction(STORE_NAME, 'readwrite');
+        tx.objectStore(STORE_NAME).put({
+          lastBackupAt: this._meta.lastBackupAt || null,
+          lastDailyDate: this._meta.lastDailyDate || null,
+          latestHash: this._meta.latestHash || null
+        }, META_KEY);
+        await this._txDone(tx);
+      } catch (err) {
+        console.warn('[Backup] failed to persist meta to IDB', err);
+      }
+      try {
+        localStorage.setItem(LOCAL_META_KEY, JSON.stringify(this._meta));
+      } catch (err) {
+        console.warn('[Backup] failed to persist meta to localStorage', err);
+      }
+    },
+
+    async _persistHandle(handle) {
+      const db = await this._openDb();
+      const tx = db.transaction(STORE_NAME, 'readwrite');
+      tx.objectStore(STORE_NAME).put(handle, HANDLE_KEY);
+      await this._txDone(tx);
+    },
+
+    async _openDb() {
+      if (this._dbPromise) return this._dbPromise;
+      this._dbPromise = new Promise((resolve, reject) => {
+        const req = indexedDB.open(DB_NAME, DB_VERSION);
+        req.onupgradeneeded = () => {
+          const db = req.result;
+          if (!db.objectStoreNames.contains(STORE_NAME)) {
+            db.createObjectStore(STORE_NAME);
+          }
+        };
+        req.onsuccess = () => resolve(req.result);
+        req.onerror = () => reject(req.error);
+      });
+      return this._dbPromise;
+    },
+
+    async _txDone(tx) {
+      return new Promise((resolve, reject) => {
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error);
+        tx.onabort = () => reject(tx.error || new Error('Transaction aborted'));
+      });
+    },
+
+    async _requestToPromise(req) {
+      return new Promise((resolve, reject) => {
+        req.onsuccess = () => resolve(req.result);
+        req.onerror = () => reject(req.error);
+      });
+    },
+
+    async hydrateMetaFromDb() {
+      try {
+        const db = await this._openDb();
+        const tx = db.transaction(STORE_NAME, 'readonly');
+        const req = tx.objectStore(STORE_NAME).get(META_KEY);
+        const meta = await this._requestToPromise(req);
+        if (meta) {
+          this._meta = Object.assign({ lastBackupAt: null, lastDailyDate: null, latestHash: null }, meta);
+          this._latestHash = this._meta.latestHash;
+          localStorage.setItem(LOCAL_META_KEY, JSON.stringify(this._meta));
+        }
+      } catch (err) {
+        console.warn('[Backup] hydrate meta error', err);
+      }
+    },
+
+    _updateStatus(status) {
+      const handleName = this._handle ? this._handle.name : null;
+      this._status = Object.assign({ code: 'idle', message: '', handleName }, status);
+      if (!('handleName' in this._status) && handleName) {
+        this._status.handleName = handleName;
+      }
+      if (!this._status.lastBackupAt && this._meta && this._meta.lastBackupAt) {
+        this._status.lastBackupAt = this._meta.lastBackupAt;
+      }
+      this._callbacks.forEach(cb => {
+        try { cb(this._status); } catch (err) { console.error('[Backup] callback error', err); }
+      });
+    }
+  };
+
+  if (typeof window !== 'undefined') {
+    window.PunchBuggyBackup = Backup;
+  }
+})();

--- a/index.html
+++ b/index.html
@@ -33,7 +33,46 @@
 
     header{
       text-align:center; font-weight:800; font-size:22px; padding:8px;
+      position:relative;
     }
+
+    .version-tag{
+      position:absolute; right:12px; top:12px; font-size:12px; font-weight:600;
+      padding:4px 8px; border-radius:999px; background:rgba(255,255,255,0.08);
+      color:var(--muted); box-shadow:0 2px 6px rgba(0,0,0,0.3);
+    }
+
+    .update-banner{
+      position:fixed; left:12px; right:12px; bottom:16px; z-index:100;
+      display:none; align-items:center; justify-content:space-between;
+      padding:12px 16px; border-radius:14px; background:linear-gradient(135deg,#12213f,#102542);
+      box-shadow:0 8px 24px rgba(0,0,0,0.45); gap:12px;
+    }
+
+    .update-banner strong{ font-size:14px; }
+
+    .update-actions{ display:flex; gap:8px; }
+
+    .update-banner button{
+      padding:10px 16px; border-radius:999px; border:none; cursor:pointer; font-weight:700;
+      background:linear-gradient(180deg,#22c997,#1aa97a); color:#fff;
+    }
+
+    .update-banner .ghost{
+      background:transparent; border:1px solid rgba(91,226,176,0.5); color:var(--muted);
+    }
+
+    .backup-panel{
+      margin-top:16px; padding:12px; border-radius:12px;
+      background:linear-gradient(180deg,rgba(15,22,40,0.9),rgba(12,19,34,0.9));
+      display:flex; flex-direction:column; gap:8px;
+    }
+
+    .backup-panel h4{ margin:0; font-size:14px; text-transform:uppercase; letter-spacing:0.08em; color:var(--muted); }
+    .backup-status{ font-size:14px; line-height:1.4; color:var(--text); }
+    .backup-meta{ font-size:12px; color:var(--muted); }
+    .backup-actions{ display:flex; gap:8px; flex-wrap:wrap; }
+    .backup-actions button{ flex:1; min-width:120px; font-size:14px; padding:10px; }
 
     .players{ display:flex; flex-direction:column; gap:14px; flex:1 }
     .card{
@@ -186,6 +225,7 @@
     <div class="app-title">
       <div class="title-main">Punch Buggy</div>
     </div>
+    <span class="version-tag">v<span id="appVersion">—</span></span>
   </header>
 
   <div class="players">
@@ -306,12 +346,35 @@
         </div>
       </div>
       <div style="font-size:13px;color:var(--muted);margin-bottom:8px">Export will download the full game state (JSON). Import will replace the current state if compatible. Logs are preserved unless cleared.</div>
+      <div class="backup-panel" id="backupPanel">
+        <h4>Local backups</h4>
+        <div class="backup-status" id="backupStatusText">Backups are disabled.</div>
+        <div class="backup-meta" id="backupMetaText"></div>
+        <div class="backup-actions">
+          <button class="back-btn" id="connectBackup">Connect folder</button>
+          <button class="back-btn" id="runBackup">Run backup</button>
+          <button class="back-btn ghost" id="disconnectBackup">Forget folder</button>
+        </div>
+      </div>
       <div style="max-height:60vh; overflow:auto;">
         <ul id="modalLog" style="list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:8px"></ul>
       </div>
     </div>
   </div>
 
+  <div class="update-banner" id="updateBanner" role="status" aria-live="polite">
+    <div>
+      <strong>Update ready</strong>
+      <div id="updateBannerText" style="font-size:13px;color:var(--muted);">A new version is available. Refresh to apply the latest fixes.</div>
+    </div>
+    <div class="update-actions">
+      <button class="ghost" id="dismissUpdate">Later</button>
+      <button id="refreshUpdate">Refresh</button>
+    </div>
+  </div>
+
+  <script src="app-version.js"></script>
+  <script src="backup.js"></script>
   <script>
     const $=sel=>document.querySelector(sel);
     const state={
@@ -324,6 +387,12 @@
   roundWinners:[],
       history:[]
     };
+
+    const Backup = window.PunchBuggyBackup;
+    const versionEl = $('#appVersion');
+    if(versionEl){
+      versionEl.textContent = window.PUNCHBUGGY_APP_VERSION || '—';
+    }
 
     function render(){
       $('#scoreA').textContent=state.players.A.score;
@@ -448,7 +517,12 @@
   if($('#headerNameB')) $('#headerNameB').textContent = state.players.B.name;
     }
 
-    function save(){localStorage.setItem('punchBuggy',JSON.stringify(state))}
+    function save(){
+      localStorage.setItem('punchBuggy',JSON.stringify(state));
+      if(Backup && typeof Backup.handleStoreSave==='function'){
+        Backup.handleStoreSave('auto');
+      }
+    }
     function load(){
       const s=localStorage.getItem('punchBuggy');
       if(s){
@@ -613,7 +687,7 @@
     };
 
     // Data modal handlers (export/import/log/clear)
-    $('#dataBtn').onclick=()=>{ $('#dataModal').style.display='flex'; renderModalLog(); };
+    $('#dataBtn').onclick=()=>{ $('#dataModal').style.display='flex'; renderModalLog(); if(typeof updateBackupUi==='function'){ updateBackupUi(Backup && Backup.getStatus ? Backup.getStatus() : {code:'unsupported'}); } };
     $('#closeData').onclick=()=>{ $('#dataModal').style.display='none'; };
     $('#clearData').onclick=()=>{ if(confirm('Clear all game data (rounds, scores, history)?')){ state.round=1; state.players.A.score=0; state.players.B.score=0; state.players.A.streak=0; state.players.B.streak=0; state.history=[]; state.roundWinners=[]; render(); } };
 
@@ -653,22 +727,157 @@
       }catch(err){ alert('Failed to import: ' + err.message); }
       e.target.value='';
     };
+
+    const backupStatusEl = $('#backupStatusText');
+    const backupMetaEl = $('#backupMetaText');
+    const connectBackupBtn = $('#connectBackup');
+    const runBackupBtn = $('#runBackup');
+    const disconnectBackupBtn = $('#disconnectBackup');
+    const connectedStatusCodes = new Set(['ready','busy','success','up-to-date','needs-permission','error']);
+
+    function describeBackupTime(ts){
+      if(!ts) return null;
+      const date = new Date(ts);
+      if(Number.isNaN(date.getTime())) return null;
+      const diff = Date.now() - date.getTime();
+      if(diff < 30 * 1000) return 'just now';
+      if(diff < 60 * 60 * 1000){
+        const mins = Math.round(diff / 60000);
+        return `${mins} minute${mins===1?'':'s'} ago`;
+      }
+      if(diff < 24 * 60 * 60 * 1000){
+        const hours = Math.round(diff / 3600000);
+        return `${hours} hour${hours===1?'':'s'} ago`;
+      }
+      return date.toLocaleString();
+    }
+
+    function updateBackupUi(status){
+      if(!backupStatusEl) return;
+      const state = status || {};
+      const code = state.code || 'idle';
+      backupStatusEl.textContent = state.message || 'Backups ready.';
+      if(backupMetaEl){
+        const details = [];
+        if(state.handleName) details.push(`Folder: ${state.handleName}`);
+        if(state.lastBackupAt){
+          const desc = describeBackupTime(state.lastBackupAt);
+          if(desc) details.push(`Last backup ${desc}`);
+        }
+        if(code === 'needs-permission') details.push('Permission required to continue automatic backups.');
+        if(code === 'unsupported') details.push('This browser does not support local folder backups.');
+        if(code === 'error' && state.error){
+          const errText = state.error && state.error.message ? state.error.message : String(state.error);
+          details.push(`Error: ${errText}`);
+        }
+        backupMetaEl.textContent = details.join(' • ');
+      }
+      const hasHandle = connectedStatusCodes.has(code);
+      if(runBackupBtn) runBackupBtn.disabled = !hasHandle || code === 'busy';
+      if(disconnectBackupBtn) disconnectBackupBtn.disabled = !hasHandle || code === 'busy';
+      if(connectBackupBtn) connectBackupBtn.disabled = code === 'busy';
+    }
+
+    if(!Backup || !Backup.SUPPORTED){
+      updateBackupUi({ code:'unsupported', message:'Backups require a compatible browser.' });
+      if(connectBackupBtn) connectBackupBtn.disabled = true;
+      if(runBackupBtn) runBackupBtn.disabled = true;
+      if(disconnectBackupBtn) disconnectBackupBtn.disabled = true;
+    }else{
+      if(connectBackupBtn) connectBackupBtn.onclick=()=>{ Backup.chooseDirectory(); };
+      if(runBackupBtn) runBackupBtn.onclick=()=>{ Backup.triggerManualBackup('manual').catch(err=>console.error('Manual backup failed',err)); };
+      if(disconnectBackupBtn) disconnectBackupBtn.onclick=()=>{
+        if(confirm('Forget this backup folder connection? Existing backup files stay on disk.')){
+          Backup.clearBackupData();
+        }
+      };
+      if(typeof Backup.hydrateMetaFromDb==='function'){
+        Backup.hydrateMetaFromDb();
+      }
+      Backup.init({ getState: ()=>state, onStatusChange: updateBackupUi });
+      updateBackupUi(Backup.getStatus());
+    }
     $('#closeRules').onclick=()=>{ $('#rulesModal').style.display='none'; };
     $('#nameA').onchange=e=>{state.players.A.name=e.target.value;render()};
     $('#nameB').onchange=e=>{state.players.B.name=e.target.value;render()};
     $('#uploadA').onchange=e=>handleImageUpload('A',e.target.files[0]);
     $('#uploadB').onchange=e=>handleImageUpload('B',e.target.files[0]);
 
-    load();
-  </script>
-  <script>
-    if ('serviceWorker' in navigator) {
-      window.addEventListener('load', () => {
-        navigator.serviceWorker.register('/service-worker.js').catch(err => {
-          console.error('Service worker registration failed:', err);
+    function setupServiceWorkerUpdates(){
+      if(!('serviceWorker' in navigator)) return;
+      const banner = $('#updateBanner');
+      const bannerText = $('#updateBannerText');
+      const refreshBtn = $('#refreshUpdate');
+      const dismissBtn = $('#dismissUpdate');
+      let waitingWorker = null;
+      let autoReloadTimer = null;
+      let refreshing = false;
+
+      function hideBanner(){
+        if(autoReloadTimer) clearTimeout(autoReloadTimer);
+        autoReloadTimer = null;
+        if(banner) banner.style.display = 'none';
+        waitingWorker = null;
+      }
+
+      function requestRefresh(){
+        if(waitingWorker){
+          const worker = waitingWorker;
+          hideBanner();
+          worker.postMessage({type:'SKIP_WAITING'});
+        }
+      }
+
+      function showBanner(worker){
+        waitingWorker = worker;
+        if(!banner) return;
+        if(bannerText){
+          const version = window.PUNCHBUGGY_APP_VERSION || 'latest';
+          bannerText.textContent = `Version ${version} is ready. Refresh to load the latest updates.`;
+        }
+        banner.style.display = 'flex';
+        if(autoReloadTimer) clearTimeout(autoReloadTimer);
+        autoReloadTimer = setTimeout(()=>{
+          if(waitingWorker){
+            requestRefresh();
+          }
+        }, 30000);
+      }
+
+      if(refreshBtn) refreshBtn.onclick=()=>requestRefresh();
+      if(dismissBtn) dismissBtn.onclick=()=>hideBanner();
+
+      navigator.serviceWorker.addEventListener('controllerchange', () => {
+        if(refreshing) return;
+        refreshing = true;
+        window.location.reload();
+      });
+
+      navigator.serviceWorker.register('/service-worker.js').then(reg=>{
+        if(reg.waiting){
+          showBanner(reg.waiting);
+        }
+        reg.addEventListener('updatefound', ()=>{
+          const newWorker = reg.installing;
+          if(!newWorker) return;
+          newWorker.addEventListener('statechange', ()=>{
+            if(newWorker.state === 'installed' && navigator.serviceWorker.controller){
+              showBanner(newWorker);
+            }
+          });
         });
+        setInterval(()=>{
+          if(document.visibilityState === 'visible'){
+            reg.update();
+          }
+        }, 5 * 60 * 1000);
+      }).catch(err=>{
+        console.error('Service worker registration failed:', err);
       });
     }
+
+    load();
+    setupServiceWorkerUpdates();
   </script>
 </body>
 </html>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,6 +1,7 @@
 {
   "name": "Punch Buggy",
   "short_name": "PunchBuggy",
+  "version": "1.0.0",
   "start_url": ".",
   "display": "standalone",
   "background_color": "#0b0f1a",

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,10 +1,14 @@
-const CACHE_VERSION = 'v2';
-const CACHE_NAME = `punchbuggy-cache-${CACHE_VERSION}`;
+importScripts('./app-version.js');
+
+const APP_VERSION = self.PUNCHBUGGY_APP_VERSION || 'dev';
+const CACHE_NAME = `punchbuggy-cache-${APP_VERSION}`;
 const APP_SHELL = [
   './',
   './index.html',
   './manifest.webmanifest',
   './service-worker.js',
+  './app-version.js',
+  './backup.js',
   './icons/punchbuggy.svg'
 ].map(path => new URL(path, self.location).toString());
 
@@ -20,7 +24,7 @@ self.addEventListener('activate', event => {
       Promise.all(
         keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
       )
-    )
+    ).then(() => self.clients.claim())
   );
 });
 
@@ -43,4 +47,10 @@ self.addEventListener('fetch', event => {
         .catch(() => caches.match(new URL('./index.html', self.location).toString()));
     })
   );
+});
+
+self.addEventListener('message', event => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
 });


### PR DESCRIPTION
## Summary
- add a reusable File System Access backup module and wire it into the data modal UI
- surface version metadata in the UI and show a service worker powered refresh banner when updates are ready
- document the release checklist for backups and updates and bump the shared app version metadata

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f0040b62308323bbd966755dd57820