### PR TITLE
fix: backend quality review — 10 correctness and robustness fixes

### DIFF
--- a/LLM_CONTEXT.md
+++ b/LLM_CONTEXT.md
@@ -1,141 +1,171 @@
-# LLM Project Context Template
-
-Use this file as `LLM_CONTEXT.md` in any repo before asking another LLM to work on it.
+# LLM Project Context — PunchBuggy
 
 ## 1) Project Snapshot
-- Project name: Punchbuggy
-- One-line description:
-- Current status: `active | prototype | draft | archived`
-- Primary owner:
-- Last updated (YYYY-MM-DD): 2026-02-18
+- Project name: PunchBuggy
+- One-line description: Mobile-first PWA scorekeeper for the "Punch Buggy" car game (spot VW Beetles, tally points).
+- Current status: `active`
+- Primary owner: BenWassa
+- Last updated (YYYY-MM-DD): 2026-06-15
 
 ## 2) Purpose and Scope
-- Problem this project solves:
-- Target users:
-- Core outcomes / success criteria:
-- In scope:
-- Out of scope:
+- Problem this project solves: Keeps score during road-trip Punch Buggy games without needing paper or a shared device.
+- Target users: Two players on a road trip using their own or a shared mobile phone.
+- Core outcomes / success criteria: Scores persist between browser sessions; rounds are recorded with full history; the app works offline.
+- In scope: Two-player scoring, round management, leaderboard, import/export of game state, PWA offline support.
+- Out of scope: Multiplayer networking, server-side persistence, more than 2 players.
 
 ## 3) Links (Use Full URLs)
 - Production app: https://benwassa.github.io/punchbuggy/
-- Staging app:
 - Repository: https://github.com/BenWassa/punchbuggy
 - Main branch: https://github.com/BenWassa/punchbuggy/tree/main
-- Active working branch: https://github.com/BenWassa/punchbuggy/tree/main
-- Docs:
-- Design files:
-- Issue tracker / board:
 
 ## 4) Tech Stack
 ### Frontend
-- Framework: N/A
-- Language: JavaScript
-- Styling: N/A
-- State management:
+- Framework: None — vanilla JavaScript ES modules
+- Language: JavaScript (no TypeScript)
+- Styling: Plain CSS with custom design-system variables (`src/styles/app.css`)
+- State management: Single in-memory `state` object; persisted via `localStorage` key `punchBuggy`
 
 ### Backend
-- Runtime/framework:
-- API style (`REST | GraphQL | RPC`):
-- Auth:
+- Runtime/framework: None — fully client-side, static hosting only
+- API style: N/A
+- Auth: N/A
 
 ### Data
-- Primary database:
-- Caching:
-- File storage:
+- Primary database: `localStorage` (key: `punchBuggy`)
+- Caching: Service worker cache (`punchbuggy-cache-<version>`)
+- File storage: Avatar images stored as base64 data URLs inside `state.players[A|B].avatar` in localStorage (max 1.5 MB per image enforced client-side)
 
 ### Tooling
 - Package manager: npm
-- Build tool: Vite
-- Test frameworks: N/A
-- Lint/format: ESLint
-- CI/CD:
+- Build tool: Vite 5 (output → `docs/` for GitHub Pages)
+- Test frameworks: None
+- Lint/format: ESLint 9 + Prettier 3
+- CI/CD: Manual release script (`scripts/release.js`); deploys via GitHub Pages from `docs/`
 
 ## 5) Architecture Overview
-- High-level architecture (2-5 bullets):
+- Single HTML file (`index.html`, ~2300 lines) contains all markup. `src/main.js` is the sole module entry.
+- All app logic (state, scoring, undo/redo, leaderboard, import/export, SW updates) lives in `src/main.js`.
+- Service worker (`public/service-worker.js`) provides offline support with versioned cache-key busting.
+- Schema migration runs on startup via `archive/migrations/migrate-to-v2.js` (imported as ES module).
 - Key folders and purpose:
-  - `src/...`:
-  - `...`:
+  - `src/`: Application source (JS + CSS)
+  - `public/`: Static assets served as-is (service worker, manifest, version file, icons)
+  - `docs/`: Vite build output — deployed to GitHub Pages
+  - `scripts/`: Release automation (bump-version.js, release.js, check-versions.js)
+  - `archive/migrations/`: Schema migration helpers (legacy data normalisation)
 - Entry points:
-  - App entry:
-  - API entry:
-- Important services/modules:
-  - Module name:
-  - Responsibility:
+  - App entry: `index.html` → `<script type="module" src="./src/main.js">`
+  - Service Worker entry: `public/service-worker.js` (registered from main.js on non-localhost)
 
 ## 6) Local Development
-- Prerequisites:
-- Install:
-  - `npm ci`
-- Run:
-  - `npm run dev`
-- Build:
-  - `npm run build`
-- Test:
-  - `N/A`
+- Prerequisites: Node.js ≥ 18, npm
+- Install: `npm install`
+- Run: `npm run dev` (Vite dev server at http://localhost:5173/punchbuggy/ — SW is skipped on localhost)
+- Build: `npm run build` (output to `docs/`)
+- Lint: `npm run lint`
+- Format: `npm run format`
+- Bump version: `npm run bump <x.y.z> [release notes]`
+- Full release: `npm run release <x.y.z> [notes]` (lint → bump → format:check → build)
 
 ## 7) Environment and Secrets
-- Required env vars:
-  - `KEY_NAME`: purpose, example format, required/optional
-- Secret management approach:
-- Safe local defaults:
+- No environment variables required.
+- No secrets. Fully client-side with no API keys.
 
 ## 8) External Dependencies
-- Third-party APIs/services:
-  - Service:
-  - Why used:
-  - Rate limits/constraints:
-- Vendor SDKs with pinned versions:
+- No third-party APIs or runtime dependencies.
+- Dev-only: ESLint, Prettier, Vite, globals (ESLint plugin).
 
 ## 9) Data Contracts
-- Main domain entities:
-- API endpoints/events used most:
-- Validation rules:
-- Migration notes (if any):
+
+### localStorage schema (`punchBuggy`, schemaVersion `2.0.0`)
+```json
+{
+  "schemaVersion": "2.0.0",
+  "round": 1,
+  "players": {
+    "A": { "name": "Player A", "score": 0, "streak": 0, "avatar": "" },
+    "B": { "name": "Player B", "score": 0, "streak": 0, "avatar": "" }
+  },
+  "roundWinners": [
+    { "winner": "A" | "B" | "T", "scoreA": 0, "scoreB": 0 }
+  ],
+  "history": ["Player A spotted a bug! +1", "..."]
+}
+```
+- `undoStack` is runtime-only (never persisted to localStorage, never exported).
+- Avatar images: base64 data URL, max 1.5 MB per upload enforced at read time.
+- `winner` field is always normalised to `'A'`, `'B'`, or `'T'` — arbitrary strings are coerced to `'T'`.
+
+### Migration
+- `archive/migrations/migrate-to-v2.js` runs on every page load before `load()`.
+- If `schemaVersion` is missing it normalises the shape and writes `schemaVersion: '2.0.0'` back.
+- `load()` itself also validates and sanitises all nested fields defensively.
+
+### Import/export
+- Export: JSON file without `undoStack`. Supports current shape and older wrapped `{ app, data }` shapes.
+- Import: `normalizeImportedState()` accepts both flat and nested player objects and both `roundWinners` and `rounds.history` shapes.
 
 ## 10) Product and UX Notes
 - Main user flows:
-- Critical screens/components:
-- Accessibility requirements:
-- Performance requirements:
+  1. Open app → names/avatars set → tap score buttons during drive → press Next Round → view leaderboard.
+  2. Export game → share JSON file → other device imports to continue.
+- Critical screens/components: Player cards (score, streak badge, avatar, crown), Next Round button, Leaderboard modal/view, Update banner.
+- Accessibility: `inert` + `aria-hidden` on the slide-out menu; focus is returned to the menu button on close.
+- Performance: Scores are the hot path; each tap triggers one render + one localStorage write.
+- Update banner: shown when a new service worker is waiting. User clicks Refresh → `SKIP_WAITING` message sent to SW → page reloads automatically via `controllerchange` event.
 
 ## 11) Quality and Testing
-- Test strategy:
-- Current coverage gaps:
+- Test strategy: No automated tests. Verify manually with `npm run dev`.
+- Current coverage gaps: No unit tests for state logic, migration, or normalisation helpers.
 - High-risk areas:
+  - `load()` / `sanitizeLoadedState()`: corruption of localStorage data.
+  - `normalizeImportedState()`: malformed import files.
+  - Service worker caching: version mismatch leaves users on stale assets.
+  - Avatar storage: large images can exhaust localStorage quota.
 - How to verify a change manually:
+  1. `npm run dev` → open http://localhost:5173/punchbuggy/
+  2. Score points, change names, next round, open leaderboard, export/import JSON.
+  3. `npm run build` → check `docs/` output size is reasonable.
+  4. `npm run lint` → should pass with zero warnings.
 
 ## 12) Current Priorities
-- Active tasks:
-  1.
-  2.
-  3.
-- Known bugs:
-- Blockers:
+- Active tasks: None (v3.4.2 is stable)
+- Known bugs: None after backend quality review (June 2026)
+- Blockers: None
 
 ## 13) Constraints for the LLM
-- Do not change:
+- Do not change: The `docs/` directory is build output — never edit it by hand.
+- Do not change: `public/app-version.js` version string — use `npm run bump <x.y.z>` instead.
 - Preferred patterns/conventions:
-- Code style rules:
-- Definition of done for PRs:
+  - Vanilla JS only — no frameworks, no TypeScript.
+  - Use `getEl()` / `setText()` / `setDisplay()` helpers instead of raw `querySelector`.
+  - All localStorage access goes through `safeStorageGet` / `safeStorageSet` / `safeStorageRemove`.
+  - `log(msg)` appends to `state.history`; callers must call `render()` themselves — `log()` does NOT render.
+  - `render()` is the single source of truth for DOM → it calls `save()` internally.
+  - `undoStack` is never persisted or exported.
+  - HTML content from player names must be escaped via `escapeHtml()` before any `innerHTML` insertion.
+- Code style rules: Prettier defaults (2-space indent, single quotes). ESLint enforces no-unused-vars and browser globals.
+- Definition of done for PRs: `npm run lint` passes, `npm run build` succeeds, manual smoke test in browser.
 
 ## 14) Suggested Prompt for Another LLM
 ```text
-You are helping on the project described below.
+You are helping maintain PunchBuggy — a vanilla-JS PWA scorekeeper with no framework and no backend.
+All logic is in src/main.js. State is persisted in localStorage. The service worker handles offline
+caching with versioned keys. Read LLM_CONTEXT.md in full before making any changes.
 
-Goals:
-1) Preserve existing architecture and conventions.
-2) Prefer minimal, safe changes.
-3) Run relevant tests and explain risk.
-
-Project context:
-[Paste completed sections from this file]
+Key rules:
+- Escape all user-supplied content before innerHTML insertion (use escapeHtml()).
+- log(msg) does not call render(); the calling function must.
+- undoStack is runtime-only; never persist or export it.
+- All localStorage access goes through the safeStorage* helpers.
+- Run `npm run lint` and `npm run build` to verify your changes before committing.
 
 Task:
 [Describe the specific task]
 ```
 
-## 15) Optional: Portfolio Metadata
-- Public tagline:
-- Demo-ready features:
-- Screenshot/GIF links:
-- Resume bullet:
+## 15) Portfolio Metadata
+- Public tagline: Offline-first PWA scorekeeper for road-trip Punch Buggy games.
+- Demo-ready features: Score tracking, round history, leaderboard with win %, export/import JSON.
+- Production URL: https://benwassa.github.io/punchbuggy/

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ No punchbacks.
 ## Features that matter
 
 - **Mobile-first UI** with oversized scores, tall action buttons, and safe-area spacing for notch devices.
-- **Player avatars** support inline uploads with a consistent SVG camera icon and accessible labels.
+- **Player avatars** support inline uploads (max 1.5 MB) with a consistent SVG camera icon and accessible labels.
 - **Leaderboard view** with head-to-head stats and round history details.
-- **Quiet updates** via the service worker with versioned cache busting (no banners or prompts).
+- **Service worker updates** with versioned cache busting; an update banner appears when a new version is ready and reloads the page automatically when confirmed.
 
 ## Versioning & release flow
 

--- a/docs/app-version.js
+++ b/docs/app-version.js
@@ -1,4 +1,2 @@
-// Application version used by the service worker and UI.
-// Application version used by the service worker and UI.
-// Major release: UI refresh, remove backups/migrations, silent updates.
+// Application version — consumed by the service worker (for cache key) and the UI version display.
 (typeof window !== 'undefined' ? window : self).PUNCHBUGGY_APP_VERSION = '3.4.2';

--- a/docs/service-worker.js
+++ b/docs/service-worker.js
@@ -15,8 +15,13 @@ const APP_SHELL = [
 ].map((path) => new URL(path, self.location).toString());
 
 self.addEventListener('install', (event) => {
-  self.skipWaiting();
-  event.waitUntil(caches.open(CACHE_NAME).then((cache) => cache.addAll(APP_SHELL)));
+  // skipWaiting inside waitUntil ensures caching completes before the SW activates
+  event.waitUntil(
+    Promise.all([
+      self.skipWaiting(),
+      caches.open(CACHE_NAME).then((cache) => cache.addAll(APP_SHELL)),
+    ])
+  );
 });
 
 self.addEventListener('activate', (event) => {
@@ -43,11 +48,14 @@ self.addEventListener('fetch', (event) => {
     event.respondWith(
       fetch(event.request)
         .then((response) => {
-          const clone = response.clone();
-          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
+          // Only cache successful responses — never cache 4xx/5xx error pages
+          if (response.ok) {
+            const clone = response.clone();
+            caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
+          }
           return response;
         })
-        .catch(() => caches.match(event.request))
+        .catch(() => caches.match(event.request).then((r) => r || caches.match(new URL('./index.html', self.location).toString())))
     );
     return;
   }
@@ -75,11 +83,18 @@ self.addEventListener('fetch', (event) => {
       }
       return fetch(event.request)
         .then((response) => {
-          const clone = response.clone();
-          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
+          // Only cache successful responses
+          if (response.ok) {
+            const clone = response.clone();
+            caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
+          }
           return response;
         })
-        .catch(() => caches.match(new URL('./index.html', self.location).toString()));
+        .catch(() =>
+          caches
+            .match(new URL('./index.html', self.location).toString())
+            .then((r) => r || new Response('Offline — no cached content available.', { status: 503, statusText: 'Service Unavailable' }))
+        );
     })
   );
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "punchbuggy",
-  "version": "0.0.0",
+  "version": "3.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "punchbuggy",
-      "version": "0.0.0",
+      "version": "3.4.2",
       "devDependencies": {
         "eslint": "^9.18.0",
         "globals": "^15.14.0",
@@ -984,7 +984,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1212,7 +1211,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2550,8 +2548,7 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -2708,7 +2705,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",

--- a/public/app-version.js
+++ b/public/app-version.js
@@ -1,4 +1,2 @@
-// Application version used by the service worker and UI.
-// Application version used by the service worker and UI.
-// Major release: UI refresh, remove backups/migrations, silent updates.
+// Application version — consumed by the service worker (for cache key) and the UI version display.
 (typeof window !== 'undefined' ? window : self).PUNCHBUGGY_APP_VERSION = '3.4.2';

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -15,8 +15,13 @@ const APP_SHELL = [
 ].map((path) => new URL(path, self.location).toString());
 
 self.addEventListener('install', (event) => {
-  self.skipWaiting();
-  event.waitUntil(caches.open(CACHE_NAME).then((cache) => cache.addAll(APP_SHELL)));
+  // skipWaiting inside waitUntil ensures caching completes before the SW activates
+  event.waitUntil(
+    Promise.all([
+      self.skipWaiting(),
+      caches.open(CACHE_NAME).then((cache) => cache.addAll(APP_SHELL)),
+    ])
+  );
 });
 
 self.addEventListener('activate', (event) => {
@@ -43,11 +48,14 @@ self.addEventListener('fetch', (event) => {
     event.respondWith(
       fetch(event.request)
         .then((response) => {
-          const clone = response.clone();
-          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
+          // Only cache successful responses — never cache 4xx/5xx error pages
+          if (response.ok) {
+            const clone = response.clone();
+            caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
+          }
           return response;
         })
-        .catch(() => caches.match(event.request))
+        .catch(() => caches.match(event.request).then((r) => r || caches.match(new URL('./index.html', self.location).toString())))
     );
     return;
   }
@@ -75,11 +83,18 @@ self.addEventListener('fetch', (event) => {
       }
       return fetch(event.request)
         .then((response) => {
-          const clone = response.clone();
-          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
+          // Only cache successful responses
+          if (response.ok) {
+            const clone = response.clone();
+            caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
+          }
           return response;
         })
-        .catch(() => caches.match(new URL('./index.html', self.location).toString()));
+        .catch(() =>
+          caches
+            .match(new URL('./index.html', self.location).toString())
+            .then((r) => r || new Response('Offline — no cached content available.', { status: 503, statusText: 'Service Unavailable' }))
+        );
     })
   );
 });

--- a/src/main.js
+++ b/src/main.js
@@ -149,6 +149,14 @@ function updateStreakBadge(el, streak) {
   }
 }
 
+function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
 function renderModalLog() {
   const list = $('#modalLog');
   if (!list) return;
@@ -156,7 +164,8 @@ function renderModalLog() {
     .slice()
     .reverse()
     .map(
-      (e) => `<li style="padding:8px;border-radius:8px;background:rgba(255,255,255,0.03)">${e}</li>`
+      (e) =>
+        `<li style="padding:8px;border-radius:8px;background:rgba(255,255,255,0.03)">${escapeHtml(e)}</li>`
     )
     .join('');
 }
@@ -333,24 +342,69 @@ function save() {
     console.warn('[PunchBuggy] Save failed (localStorage may be full or unavailable).');
   }
 }
+function sanitizeLoadedState(parsed) {
+  // Ensure top-level shape is safe before assigning into state
+  if (!parsed || typeof parsed !== 'object') return null;
+
+  // Guard players: must be an object with A and B sub-objects
+  if (!parsed.players || typeof parsed.players !== 'object') {
+    parsed.players = {
+      A: { name: 'Player A', score: 0, streak: 0, avatar: '' },
+      B: { name: 'Player B', score: 0, streak: 0, avatar: '' },
+    };
+  } else {
+    ['A', 'B'].forEach((k) => {
+      const p = parsed.players[k];
+      if (!p || typeof p !== 'object') {
+        parsed.players[k] = { name: `Player ${k}`, score: 0, streak: 0, avatar: '' };
+      } else {
+        parsed.players[k] = {
+          name: typeof p.name === 'string' && p.name.trim() ? p.name.trim() : `Player ${k}`,
+          score: typeof p.score === 'number' ? p.score : Number(p.score) || 0,
+          streak: typeof p.streak === 'number' ? p.streak : Number(p.streak) || 0,
+          avatar: typeof p.avatar === 'string' ? p.avatar : '',
+        };
+      }
+    });
+  }
+
+  // Migrate roundWinners legacy strings to objects
+  if (Array.isArray(parsed.roundWinners)) {
+    parsed.roundWinners = parsed.roundWinners
+      .map((r) => {
+        if (!r) return null;
+        if (typeof r === 'string') {
+          if (r === 'A') return { winner: 'A', scoreA: 0, scoreB: 0 };
+          if (r === 'B') return { winner: 'B', scoreA: 0, scoreB: 0 };
+          return { winner: 'T', scoreA: 0, scoreB: 0 };
+        }
+        // Validate winner value
+        const winner = r.winner === 'A' || r.winner === 'B' ? r.winner : 'T';
+        return {
+          winner,
+          scoreA: typeof r.scoreA === 'number' ? r.scoreA : Number(r.scoreA) || 0,
+          scoreB: typeof r.scoreB === 'number' ? r.scoreB : Number(r.scoreB) || 0,
+        };
+      })
+      .filter(Boolean);
+  } else {
+    parsed.roundWinners = [];
+  }
+
+  parsed.round = typeof parsed.round === 'number' && parsed.round >= 1 ? Math.round(parsed.round) : 1;
+  parsed.history = Array.isArray(parsed.history) ? parsed.history.filter((h) => typeof h === 'string') : [];
+
+  return parsed;
+}
+
 function load() {
   const s = safeStorageGet('punchBuggy');
   if (s) {
     try {
       const parsed = JSON.parse(s);
-      if (parsed && typeof parsed === 'object') {
-        // migrate roundWinners legacy strings to objects
-        if (parsed.roundWinners && Array.isArray(parsed.roundWinners)) {
-          parsed.roundWinners = parsed.roundWinners.map((r) => {
-            if (typeof r === 'string') {
-              if (r === 'A') return { winner: 'A', scoreA: 0, scoreB: 0 };
-              if (r === 'B') return { winner: 'B', scoreA: 0, scoreB: 0 };
-              return { winner: 'T', scoreA: 0, scoreB: 0 };
-            }
-            return r;
-          });
-        }
-        Object.assign(state, parsed);
+      const safe = sanitizeLoadedState(parsed);
+      if (safe) {
+        Object.assign(state, safe);
       }
     } catch (err) {
       console.warn('[PunchBuggy] Failed to parse saved game state, clearing storage.', err);
@@ -363,7 +417,6 @@ function load() {
 
 function log(msg) {
   state.history.push(msg);
-  render();
 }
 
 function score(p, d = 1) {
@@ -435,8 +488,8 @@ function undo() {
 function recordRoundWinner() {
   const a = state.players.A.score;
   const b = state.players.B.score;
-  const playerAName = state.players && state.players.A ? state.players.A.name : 'Player A';
-  const playerBName = state.players && state.players.B ? state.players.B.name : 'Player B';
+  const playerAName = state.players.A.name;
+  const playerBName = state.players.B.name;
   let win = 'T';
   if (a > b) win = 'A';
   else if (b > a) win = 'B';
@@ -455,11 +508,19 @@ function nextRound() {
     p.streak = 0;
   });
   log(`🏁 Round ${state.round} started!`);
-  render();
+  render(); // single render after all state mutations
 }
+
+const AVATAR_MAX_BYTES = 1.5 * 1024 * 1024; // 1.5 MB — keeps base64 under ~2 MB
 
 function handleImageUpload(player, file) {
   if (!file || !file.type.startsWith('image/')) return;
+  if (file.size > AVATAR_MAX_BYTES) {
+    alert(
+      `Image is too large (${(file.size / 1024 / 1024).toFixed(1)} MB). Please choose an image under 1.5 MB.`
+    );
+    return;
+  }
   const reader = new FileReader();
   reader.onload = (e) => {
     state.players[player].avatar = e.target.result;
@@ -572,9 +633,11 @@ onClick('#clearData', () => {
   }
 });
 
-// Export state as JSON file
+// Export state as JSON file (exclude runtime-only undoStack)
 onClick('#exportData', () => {
-  const payload = JSON.stringify(state, null, 2);
+  const exportable = { ...state };
+  delete exportable.undoStack;
+  const payload = JSON.stringify(exportable, null, 2);
   const blob = new Blob([payload], { type: 'application/json' });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
@@ -629,11 +692,13 @@ function normalizeImportedState(parsed) {
     out.round = Math.max(1, Math.round(Number(source.rounds.current.number)));
   else out.round = 1;
 
+  const validWinner = (v) => (v === 'A' || v === 'B' ? v : 'T');
+
   // Round winners: try to map from `rounds.history` if present, otherwise use roundWinners if available
   out.roundWinners = [];
   if (source.rounds && Array.isArray(source.rounds.history)) {
     out.roundWinners = source.rounds.history.map((r) => {
-      const winner = r && r.winner ? r.winner : 'T';
+      const winner = validWinner(r && r.winner);
       const scoreA = r && r.scores && Number.isFinite(Number(r.scores.A)) ? Number(r.scores.A) : 0;
       const scoreB = r && r.scores && Number.isFinite(Number(r.scores.B)) ? Number(r.scores.B) : 0;
       return { winner, scoreA, scoreB };
@@ -641,12 +706,15 @@ function normalizeImportedState(parsed) {
   } else if (Array.isArray(source.roundWinners)) {
     out.roundWinners = source.roundWinners
       .map((r) => {
+        if (!r) return null;
         if (typeof r === 'string') {
-          if (r === 'A') return { winner: 'A', scoreA: 0, scoreB: 0 };
-          if (r === 'B') return { winner: 'B', scoreA: 0, scoreB: 0 };
-          return { winner: 'T', scoreA: 0, scoreB: 0 };
+          return { winner: validWinner(r), scoreA: 0, scoreB: 0 };
         }
-        return r;
+        return {
+          winner: validWinner(r.winner),
+          scoreA: Number.isFinite(Number(r.scoreA)) ? Number(r.scoreA) : 0,
+          scoreB: Number.isFinite(Number(r.scoreB)) ? Number(r.scoreB) : 0,
+        };
       })
       .filter(Boolean);
   }
@@ -739,6 +807,7 @@ function setupServiceWorkerUpdates() {
   const root = document.documentElement;
   let waitingWorker = null;
   let autoReloadTimer = null;
+  let updateRequested = false; // tracks that a reload is pending after SKIP_WAITING
 
   function applyBannerOffset() {
     if (!banner || banner.style.display === 'none') return;
@@ -770,6 +839,7 @@ function setupServiceWorkerUpdates() {
         '[PunchBuggy] Update requested, new version will be:',
         window.PUNCHBUGGY_APP_VERSION
       );
+      updateRequested = true; // set BEFORE hideBanner() clears waitingWorker
       hideBanner();
       worker.postMessage({ type: 'SKIP_WAITING' });
     }
@@ -818,9 +888,9 @@ function setupServiceWorkerUpdates() {
   };
 
   navigator.serviceWorker.addEventListener('controllerchange', () => {
-    // Only reload the page when an update was pending (banner was shown).
-    if (!waitingWorker) return;
-    // proceed with reload
+    // Only reload when the user (or auto-timer) explicitly requested a refresh.
+    // waitingWorker is already null here (cleared by hideBanner), so we use updateRequested.
+    if (!updateRequested) return;
     window.location.reload();
   });
 


### PR DESCRIPTION
Security:
- Escape HTML in renderModalLog() to prevent stored XSS via player names

Service worker:
- Fix reload never firing after user clicks Refresh (waitingWorker was
  nulled before controllerchange; now uses a separate updateRequested flag)
- Move skipWaiting() inside event.waitUntil(Promise.all([...])) so the SW
  cannot activate before the app shell is fully cached
- Guard navigation and asset caching with response.ok to avoid persisting
  4xx/5xx error pages
- Return a 503 Response (not undefined) from the offline fallback when
  index.html is not yet in cache

State/data:
- Add sanitizeLoadedState() to deeply validate loaded state; prevents
  crashes from corrupted or null players object in localStorage
- Validate winner values in load(), normalizeImportedState(), and
  sanitizeLoadedState() — always coerce to 'A', 'B', or 'T'
- Enforce 1.5 MB limit on avatar uploads to prevent localStorage quota exhaustion
- Strip undoStack from JSON export (was serialising up to 50 full state clones)

Performance:
- log() no longer calls render(); each call site renders exactly once,
  eliminating 2-3 redundant renders and localStorage writes per score event

Docs:
- Fill out LLM_CONTEXT.md with complete project context (was empty template)
- Fix README: update banner description was stale

https://claude.ai/code/session_01Cmui8M8hccRPkzc3jyXJ81